### PR TITLE
Replace references to conduit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Conduit #
+# Contributing to linkerd2-proxy-api #
 
 :balloon: Thanks for your help improving the project!
 
 ## Getting Help ##
 
-If you have a question about Conduit or have encountered problems using it,
+If you have a question about Linkerd2 or have encountered problems using it,
 start by [asking a question in the forums][discourse] or join us in the
-[#conduit Slack channel][slack].
+(yet-to-be-renamed) [#conduit Slack channel][slack].
 
 ## Certificate of Origin ##
 
@@ -35,8 +35,8 @@ Do you have an improvement?
 3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 4. Submit a pull request against this repo's `master` branch.
 5. Your branch may be merged once all configured checks pass, including:
-    - 2 code review approvals, at least 1 of which is from a [runconduit organization member][members].
     - The branch has passed tests in CI.
+    - A review from appropriate maintainers (see [MAINTAINERS.md](MAINTAINERS.md) and [GOVERNANCE.md](GOVERNANCE.md))
 
 ## Committing ##
 
@@ -98,6 +98,8 @@ Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.
 
 [discourse]: https://discourse.linkerd.io/c/conduit
-[issue]: https://github.com/runconduit/conduit/issues/new
-[members]: https://github.com/orgs/runconduit/people
+[governance]: GOVERNANCE.md
+[issue]: https://github.com/linkerd/linkerd2/issues/new
+[maintainers]: MAINTAINERS.md
+[members]: https://github.com/orgs/linkerd/people
 [slack]: http://slack.linkerd.io/

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,14 @@ else
 endif
 
 $(PROTOC):
+	mkdir -p $(TARGET)
 	$(CURL) -Lo $(PROTOC).zip $(PROTOC_URL)
 	$(UNZIP) -p $(PROTOC).zip bin/protoc >$(PROTOC)
 	rm $(PROTOC).zip
 	chmod 755 $(PROTOC)
 
 $(DEP):
+	mkdir -p $(TARGET)
 	$(CURL) -Lso $(DEP) $(DEP_URL)
 	chmod 755 $(DEP)
 

--- a/go/destination/destination.pb.go
+++ b/go/destination/destination.pb.go
@@ -385,9 +385,9 @@ func _TlsIdentity_OneofSizer(msg proto.Message) (n int) {
 // Verify the certificate based on the Kubernetes pod identity.
 type TlsIdentity_K8SPodIdentity struct {
 	// The pod_identity string is of the format:
-	// {owner_name}.{owner_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
+	// {owner_name}.{owner_type}.{pod_ns}.linkerd-managed.{controller_ns}.svc.cluster.local
 	PodIdentity string `protobuf:"bytes,1,opt,name=pod_identity,json=podIdentity" json:"pod_identity,omitempty"`
-	// The Kubernetes namespace of the pod's Conduit control plane.
+	// The Kubernetes namespace of the pod's Linkerd2 control plane.
 	ControllerNs string `protobuf:"bytes,2,opt,name=controller_ns,json=controllerNs" json:"controller_ns,omitempty"`
 }
 

--- a/proto/destination.proto
+++ b/proto/destination.proto
@@ -97,9 +97,9 @@ message TlsIdentity {
   // Verify the certificate based on the Kubernetes pod identity.
   message K8sPodIdentity {
     // The pod_identity string is of the format:
-    // {owner_name}.{owner_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
+    // {owner_name}.{owner_type}.{pod_ns}.linkerd-managed.{controller_ns}.svc.cluster.local
     string pod_identity = 1;
-    // The Kubernetes namespace of the pod's Conduit control plane.
+    // The Kubernetes namespace of the pod's Linkerd2 control plane.
     string controller_ns = 2;
   }
 }


### PR DESCRIPTION
Update CONTRIBUTING.md to remove references to Conduit, similar to to linkerd/linkerd2-proxy#6. I'm also removing references to Conduit in the destination.proto file, and regenerating the go protobuf bindings.

Note: in order to regenerate the protobuf bindings in a fresh repo checkout, I had to modify the Makefile to first create the `target` directory in the event that it does not exist. Without the Makefile change, I got:

```
$ make go
curl -s -Lso target/dep-0.4.1 https://github.com/golang/dep/releases/download/v0.4.1/dep-darwin-amd64
make: *** [target/dep-0.4.1] Error 23
```

Not an expert in make though, so let me know if there's a better way to go about it.