### PR TITLE
Fix rust compilation for 'arbitrary' feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,7 @@ ifdef CARGO_VERBOSE
 	CARGO = cargo --verbose
 endif
 
-ifndef TEST_FLAKEY
-	TEST_FLAGS = --no-default-features
-endif
-CARGO_TEST = $(CARGO) test --frozen $(RELEASE) $(TEST_FLAGS)
+CARGO_TEST = $(CARGO) test --frozen $(RELEASE) --all-features
 
 CURL = curl -s
 GIT = git

--- a/rs/src/arbitrary.rs
+++ b/rs/src/arbitrary.rs
@@ -4,6 +4,7 @@ use std::boxed::Box;
 
 use quickcheck::*;
 
+use super::http_types::*;
 use super::net::*;
 use super::tap::*;
 


### PR DESCRIPTION
The rust package includes a special 'arbitrary' feature flag to support
quickcheck integration. This feature flag was not tested via `make rs`.

Commit 1a82147 created an `http_types` module that was not imported in
the `arbitrary` module.

This change adds the `--all-features` flag to cargo for `make rs` and
fixes compilation.