### PR TITLE
Bump `quickcheck` dependency to 0.8.0

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [features]
 default = []
-arbitrary = ["quickcheck"]
+arbitrary = ["quickcheck", "rand"]
 
 [dependencies]
 bytes = "0.4"
@@ -19,8 +19,8 @@ prost-types = "0.4.0"
 
 tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", default-features = false, features = ["protobuf"] }
 
-quickcheck = { version = "0.6", default-features = false, optional = true }
-
+quickcheck = { version = "0.8", default-features = false, optional = true }
+rand = { version = "0.6", optional = true }
 
 [build-dependencies]
 tower-grpc-build = { git = "https://github.com/tower-rs/tower-grpc", default-features = false }

--- a/rs/src/arbitrary.rs
+++ b/rs/src/arbitrary.rs
@@ -3,13 +3,14 @@
 use std::boxed::Box;
 
 use quickcheck::*;
+use rand::Rng;
 
 use super::http_types::*;
 use super::net::*;
 use super::tap::*;
 
 impl Arbitrary for ObserveRequest {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         ObserveRequest {
             limit: g.gen(),
             match_: Arbitrary::arbitrary(g),
@@ -18,7 +19,7 @@ impl Arbitrary for ObserveRequest {
 }
 
 impl Arbitrary for observe_request::Match {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::Match {
             match_: Arbitrary::arbitrary(g),
         }
@@ -26,7 +27,7 @@ impl Arbitrary for observe_request::Match {
 }
 
 impl Arbitrary for observe_request::match_::Match {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         match g.gen::<u32>() % 6 {
             0 => observe_request::match_::Match::All(Arbitrary::arbitrary(g)),
             1 => observe_request::match_::Match::Any(Arbitrary::arbitrary(g)),
@@ -40,7 +41,7 @@ impl Arbitrary for observe_request::match_::Match {
 }
 
 impl Arbitrary for observe_request::match_::Seq {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::Seq {
             matches: Arbitrary::arbitrary(g),
         }
@@ -56,7 +57,7 @@ impl Arbitrary for observe_request::match_::Seq {
 }
 
 impl Arbitrary for observe_request::match_::Label {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::Label {
             key: Arbitrary::arbitrary(g),
             value: Arbitrary::arbitrary(g),
@@ -65,7 +66,7 @@ impl Arbitrary for observe_request::match_::Label {
 }
 
 impl Arbitrary for observe_request::match_::Tcp {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::Tcp {
             match_: Arbitrary::arbitrary(g),
         }
@@ -73,7 +74,7 @@ impl Arbitrary for observe_request::match_::Tcp {
 }
 
 impl Arbitrary for observe_request::match_::tcp::Match {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         use self::observe_request::match_::tcp;
 
         if g.gen::<bool>() {
@@ -85,7 +86,7 @@ impl Arbitrary for observe_request::match_::tcp::Match {
 }
 
 impl Arbitrary for observe_request::match_::tcp::PortRange {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::tcp::PortRange {
             min: g.gen(),
             max: g.gen(),
@@ -94,7 +95,7 @@ impl Arbitrary for observe_request::match_::tcp::PortRange {
 }
 
 impl Arbitrary for observe_request::match_::tcp::Netmask {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         let ip: Option<IpAddress> = Arbitrary::arbitrary(g);
         let mask = match ip.as_ref().and_then(|a| a.ip.as_ref()) {
             Some(&ip_address::Ip::Ipv4(_)) => g.gen::<u32>() % 32 + 1,
@@ -109,7 +110,7 @@ impl Arbitrary for observe_request::match_::tcp::Netmask {
 }
 
 impl Arbitrary for observe_request::match_::Http {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::Http {
             match_: Arbitrary::arbitrary(g),
         }
@@ -117,7 +118,7 @@ impl Arbitrary for observe_request::match_::Http {
 }
 
 impl Arbitrary for observe_request::match_::http::Match {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         use self::observe_request::match_::http;
 
         match g.gen::<u32>() % 4 {
@@ -131,7 +132,7 @@ impl Arbitrary for observe_request::match_::http::Match {
 }
 
 impl Arbitrary for observe_request::match_::http::StringMatch {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         observe_request::match_::http::StringMatch {
             match_: Arbitrary::arbitrary(g),
         }
@@ -139,7 +140,7 @@ impl Arbitrary for observe_request::match_::http::StringMatch {
 }
 
 impl Arbitrary for observe_request::match_::http::string_match::Match {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         use self::observe_request::match_::http::string_match;
 
         match g.gen::<u32>() % 2 {
@@ -151,7 +152,7 @@ impl Arbitrary for observe_request::match_::http::string_match::Match {
 }
 
 impl Arbitrary for IpAddress {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         IpAddress {
             ip: Arbitrary::arbitrary(g),
         }
@@ -159,7 +160,7 @@ impl Arbitrary for IpAddress {
 }
 
 impl Arbitrary for ip_address::Ip {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         if g.gen::<bool>() {
             ip_address::Ip::Ipv4(g.gen())
         } else {
@@ -169,7 +170,7 @@ impl Arbitrary for ip_address::Ip {
 }
 
 impl Arbitrary for IPv6 {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         IPv6 {
             first: g.gen(),
             last: g.gen(),
@@ -178,7 +179,7 @@ impl Arbitrary for IPv6 {
 }
 
 impl Arbitrary for HttpMethod {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         HttpMethod {
             type_: Arbitrary::arbitrary(g),
         }
@@ -186,7 +187,7 @@ impl Arbitrary for HttpMethod {
 }
 
 impl Arbitrary for http_method::Type {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         match g.gen::<u16>() % 9 {
             8 => http_method::Type::Unregistered(String::arbitrary(g)),
             n => http_method::Type::Registered(i32::from(n).into()),
@@ -195,7 +196,7 @@ impl Arbitrary for http_method::Type {
 }
 
 impl Arbitrary for Scheme {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         Scheme {
             type_: Arbitrary::arbitrary(g),
         }
@@ -203,7 +204,7 @@ impl Arbitrary for Scheme {
 }
 
 impl Arbitrary for scheme::Type {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary<G: Gen + Rng>(g: &mut G) -> Self {
         match g.gen::<u16>() % 3 {
             3 => scheme::Type::Unregistered(String::arbitrary(g)),
             n => scheme::Type::Registered(i32::from(n).into()),

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -6,6 +6,8 @@ extern crate prost_derive;
 extern crate prost_types;
 #[cfg(feature = "arbitrary")]
 extern crate quickcheck;
+#[cfg(feature = "arbitrary")]
+extern crate rand;
 extern crate tower_grpc;
 
 use std::fmt;


### PR DESCRIPTION
This is in service of an attempt to have the proxy depend only on a
single version of `rand` (linkerd/linkerd2-proxy#170); `quickcheck` 0.6
depends on a much older `rand` than most of our other dependencies.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>