### PR TITLE
Update for v0.1.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v0.1.10
+
+* Add headers and trailers to Tap events
+* Update tower-grpc to 0.1 from crates.io
+
+## v0.1.9
+
+* Add traffic split to profiles API
+
 ## v0.1.8
 
 * Update Rust dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.8"
+version = "0.1.10"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.1.8"
+version = "0.1.10"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 publish = false
 


### PR DESCRIPTION
## v0.1.10

 * Add headers and trailers to Tap events
* Update tower-grpc to 0.1 from crates.io

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>