### PR TITLE
v0.1.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v0.1.13
+
+* Update Rust crate to use `tonic` instead of `tower-grpc`
+* Update `grpc-go` dependencies
+
 ## v0.1.12
 
 * Add `AuthorityOverride` to  `WeightedAddr`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "h2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
 edition = "2018"


### PR DESCRIPTION
- Update Rust crate to use `tonic` instead of `tower-grpc`
- Update `grpc-go` dependencies