### PR TITLE
rust: Add a rustfmt feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ rs: Cargo.lock
 
 .PHONY: go
 go: $(PROTOC)
-	$(GO) get -u github.com/golang/protobuf/protoc-gen-go
+	$(GO) get github.com/golang/protobuf/protoc-gen-go
 	$(PROTOC_GO) proto/destination.proto
 	$(PROTOC_GO) proto/http_types.proto
 	$(PROTOC_GO) proto/identity.proto

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ ifdef CARGO_VERBOSE
 	CARGO = cargo --verbose
 endif
 
-CARGO_TEST = $(CARGO) test --locked $(RELEASE) --all-features
-
 CURL = curl -s
 GIT = git
 GO = go
@@ -49,7 +47,7 @@ Cargo.lock: Cargo.toml rs/Cargo.toml
 
 .PHONY: rs
 rs: Cargo.lock
-	$(CARGO_TEST)
+	cd rs && $(CARGO) test --locked $(RELEASE) --features=arbitrary
 
 .PHONY: go
 go: $(PROTOC)

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 [features]
 # Generate code that is compatible with Tonic's `transport` module.
 transport = ["tonic-build/transport", "tonic/transport"]
+# Generate code that is formatted.
+rustfmt = ["tonic-build/rustfmt"]
 # Enable generation of arbitrary protos with quickcheck.
 arbitrary = ["quickcheck", "rand"]
 


### PR DESCRIPTION
When debugging generated code, it's useful to enable rustfmt so that
it's legible. This change makes this a feature flag.

The makefile is updated to avoid requiring rustfmt with `make rs` which
is used in CI.