### PR TITLE
go: Do not upgrade protoc-gen-go on `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ rs: Cargo.lock
 
 .PHONY: go
 go: $(PROTOC)
-	$(GO) get -u github.com/golang/protobuf/protoc-gen-go
+	$(GO) get github.com/golang/protobuf/protoc-gen-go
 	$(PROTOC_GO) proto/destination.proto
 	$(PROTOC_GO) proto/http_types.proto
 	$(PROTOC_GO) proto/identity.proto


### PR DESCRIPTION
`make go` invokes `go get -u ...` on protoc-gen-go, which causes it to
be upgraded in CI, causing CI to fail when a newer version is available.

This change removes the `-u` flag to prevent updating to a newer version
than is vendored.