### PR TITLE
rust: Use thiserror for error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "prost",
  "prost-types",
  "quickcheck",
+ "thiserror",
  "tonic",
  "tonic-build",
 ]
@@ -567,6 +568,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -8,22 +8,25 @@ edition = "2018"
 
 [features]
 default = []
+
 # Generate code that is compatible with Tonic's `transport` module.
 transport = ["tonic-build/transport", "tonic/transport"]
+
 # Generate code that is formatted.
 rustfmt = ["tonic-build/rustfmt"]
+
 # Enable generation of arbitrary protos with quickcheck.
 arbitrary = ["quickcheck"]
 
-# Determiines whether clients or servers are built
-client = []
-server = []
+# Determines whether clients or servers are built
+client = ["transport"]
+server = ["transport"]
 
-http_types = ["h2", "http"]
+http_types = ["http", "thiserror"]
 identity = ["prost-types"]
 destination = ["http_types", "net", "prost-types"]
-net = ["ipnet"]
-tap = ["http_types", "net", "prost-types"]
+net = ["ipnet", "thiserror"]
+tap = ["h2", "http_types", "net", "prost-types"]
 
 [dependencies]
 h2 = { version = "0.3", optional = true }
@@ -32,6 +35,7 @@ ipnet = { version = "2", optional = true }
 prost = "0.7"
 prost-types = { version = "0.7", optional = true }
 quickcheck = { version = "1", default-features = false, optional = true }
+thiserror = { version = "1", optional = true }
 tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
 
 [build-dependencies]

--- a/rs/src/gen/http_types.rs
+++ b/rs/src/gen/http_types.rs
@@ -1,18 +1,19 @@
 use std::{
     borrow::Cow,
     convert::{TryFrom, TryInto},
-    error::Error,
-    fmt,
 };
+use thiserror::Error;
 
 tonic::include_proto!("io.linkerd.proxy.http_types");
 
 /// Indicates an HTTP Method could not be decoded.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Error)]
+#[error("invalid HTTP method")]
 pub struct InvalidMethod;
 
 /// Indicates a URI Scheme could not be decoded.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Error)]
+#[error("invalid HTTP scheme")]
 pub struct InvalidScheme;
 
 // === impl scheme::Type ===
@@ -99,16 +100,6 @@ impl<'a> From<&'a http::Method> for HttpMethod {
     }
 }
 
-// === impl InvalidMethod ===
-
-impl fmt::Display for InvalidMethod {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid http method")
-    }
-}
-
-impl Error for InvalidMethod {}
-
 // === impl Scheme ===
 
 impl<'a> From<&'a http::uri::Scheme> for Scheme {
@@ -136,16 +127,6 @@ impl<'a> From<&'a str> for Scheme {
         }
     }
 }
-
-// === impl InvalidScheme ===
-
-impl fmt::Display for InvalidScheme {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid http scheme")
-    }
-}
-
-impl Error for InvalidScheme {}
 
 #[cfg(feature = "arbitrary")]
 mod arbitary {

--- a/rs/src/gen/net.rs
+++ b/rs/src/gen/net.rs
@@ -1,20 +1,20 @@
-use std::{
-    convert::{TryFrom, TryInto},
-    error::Error,
-    fmt,
-};
+use std::convert::{TryFrom, TryInto};
+use thiserror::Error;
 
 tonic::include_proto!("io.linkerd.proxy.net");
 
 /// Indicates an IP address could not be decoded.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Error)]
+#[error("invalid IP address")]
 pub struct InvalidIpAddress;
 
 /// Indicates an IP address could not be decoded.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Error)]
 pub enum InvalidIpNetwork {
-    Ip(InvalidIpAddress),
-    PrefixLen(ipnet::PrefixLenError),
+    #[error("invalid IP address")]
+    Ip(#[from] InvalidIpAddress),
+    #[error("invalid network prefix length")]
+    PrefixLen(#[from] ipnet::PrefixLenError),
 }
 
 // === impl IpAddress ===
@@ -210,16 +210,6 @@ impl TryFrom<TcpAddress> for std::net::SocketAddr {
         Err(InvalidIpAddress)
     }
 }
-
-// === impl InvalidIpAddress ===
-
-impl fmt::Display for InvalidIpAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid ip address")
-    }
-}
-
-impl Error for InvalidIpAddress {}
 
 #[cfg(feature = "arbitrary")]
 mod arbitary {


### PR DESCRIPTION
The `thiserror` crate reduces boilplate for error types. This change
updates the `net` and `http_types` errors to use `thiserror`. This fixes
a missing error implementation for `InvalidIpNetwork`.

This change also updates some conditional depdencies to behave as
expected:
- the `http_types` module does not use `h2`--this is only needed by `tap`;
- the `client` and `server` feature shoudl imply `transport`--these
  features are useless without transport bindings.