### PR TITLE
update to `tonic` 0.6 and `prost` 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This branch updates the Rust bindings to use v0.6 of `tonic` and v0.9 of
`prost`. Updating the proxy API crate is necessary in order to update
the proxy's dependencies on these crates.