### PR TITLE
http: add `PATCH` variant during parsing

### DIFF
--- a/src/gen/http_types.rs
+++ b/src/gen/http_types.rs
@@ -83,6 +83,7 @@ impl<'a> From<&'a http::Method> for http_method::Type {
             http::Method::POST => Type::Registered(Registered::Post.into()),
             http::Method::PUT => Type::Registered(Registered::Put.into()),
             http::Method::DELETE => Type::Registered(Registered::Delete.into()),
+            http::Method::PATCH => Type::Registered(Registered::Patch.into()),
             http::Method::HEAD => Type::Registered(Registered::Head.into()),
             http::Method::OPTIONS => Type::Registered(Registered::Options.into()),
             http::Method::CONNECT => Type::Registered(Registered::Connect.into()),


### PR DESCRIPTION
This PR adds the missing `PATCH` variant in the http method
parsing logic. This prevents the `PATCH` method from
being marked as Unregistered in the TAP responses.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>