### PR TITLE
v0.3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v0.3.1
+
+* Rust: Fix serialization of `http::Method::PATCH` to use a registered method
+
+## v0.3.0
+
+* Rust: Update `tonic` to v0.6 and `prost` to v0.9
+* Go: Update `google.golang.org/grpc` to v1.43.0
+
 ## v0.2.0
 
 * Add the `io.linkerd.proxy.inbound.InboundServerPolicies` API to support server-side configuration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
* Rust: Fix serialization of `http::Method::PATCH` to use a registered method