### PR TITLE
Add missing Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"
 description = "Linkerd2 Proxy API gRPC bindings and utilities"
+homepage = "https://linkerd.io"
+repository = "https://github.com/linkerd/linkerd2-proxy-api"
+documentation = "https://docs.rs/linkerd2-proxy-api"
+keyword = ["linkerd", "grpc", "servicemesh"]
 
 [features]
 default = []


### PR DESCRIPTION
Cargo expects various links to be defined in published crate manifests.
This change adds homepage, repository, and documentation links.