### PR TITLE
ci: Run clippy, tests on all cargo features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  RUSTFLAGS: "-D warnings -A deprecated"
   RUSTUP_MAX_RETRIES: 10
 
 permissions:
@@ -42,7 +43,7 @@ jobs:
       - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
-      - run: just rs-clippy
+      - run: just rs-clippy --all-features
 
   rust-docs:
     timeout-minutes: 10
@@ -66,8 +67,8 @@ jobs:
       - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
-      - run: just rs-test-build
-      - run: just rs-test
+      - run: just rs-test-build --all-features
+      - run: just rs-test --all-features
 
   rust-deps:
     timeout-minutes: 5

--- a/justfile
+++ b/justfile
@@ -24,7 +24,6 @@ export PROTOC_NO_VENDOR := "1"
 ##
 
 export RUST_BACKTRACE := env_var_or_default("RUST_BACKTRACE", "short")
-export RUSTFLAGS := env_var_or_default("RUSTFLAGS", "-D warnings -A deprecated")
 
 cargo_toolchain := ""
 cargo := "cargo" + if cargo_toolchain != "" { " +" + cargo_toolchain } else { "" }


### PR DESCRIPTION
Our Rust CI currently does not run `clippy` and `test` with
`--all-features`, so these checks are effectively being skipped today.

This change adds `--all-features` so that all rust modules are checked.

Furthermore, the `justfile` has been updated to no longer set
`RUSTFLAGS` so that rust-analyzer, etc can use the same cached object
files without rebuilding. The `RUSTFLAGS` configuration has been moved
to the GitHub workflow.

Signed-off-by: Oliver Gould <ver@buoyant.io>