### PR TITLE
v0.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # `linkerd2-proxy-api` changes
 
+## v0.6.0
+
+* Add HTTP and gRPC Route types
+* Add a resource Metadata type
+* Go: update `google.golang.org/grpc` to v1.48
+* Rust: Make error types cloneable
+* Rust: Update `http_types` converters and enum matching
+* Rust: Rename the `http_types` feature to `http-types`
+
 ## v0.5.0
 
 * Rust: Remove the build-time dependency on `protoc`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
* Add HTTP and gRPC Route types
* Add a resource Metadata type
* Go: update `google.golang.org/grpc` to v1.48
* Rust: Make error types cloneable
* Rust: Update `http_types` converters and enum matching
* Rust: Rename the `http_types` feature to `http-types`

Signed-off-by: Oliver Gould <ver@buoyant.io>