### PR TITLE
rust: bump `prost-build` to 0.11.1, undo whitespace change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49d928704208aba2cb1fb022ce1a319bdedcb03caf51ddf82734fa903407762"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
  "heck",

--- a/src/gen/io.linkerd.proxy.destination.rs
+++ b/src/gen/io.linkerd.proxy.destination.rs
@@ -4,12 +4,12 @@ pub struct GetDestination {
     pub scheme: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub path: ::prost::alloc::string::String,
-    ///  An opaque value that is set at injection-time and sent with destintion
-    ///  lookups.
+    /// An opaque value that is set at injection-time and sent with destintion
+    /// lookups.
     ///
-    ///  If, for instance, the token encodes a namespace or some locality
-    ///  information, the service may alter its results to take this locality into
-    ///  account.
+    /// If, for instance, the token encodes a namespace or some locality
+    /// information, the service may alter its results to take this locality into
+    /// account.
     #[prost(string, tag="3")]
     pub context_token: ::prost::alloc::string::String,
 }
@@ -22,18 +22,18 @@ pub struct Update {
 pub mod update {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Update {
-        ///  A new set of endpoints are available for the service. The set might be
-        ///  empty.
+        /// A new set of endpoints are available for the service. The set might be
+        /// empty.
         #[prost(message, tag="1")]
         Add(super::WeightedAddrSet),
-        ///  Some endpoints have been removed from the service.
+        /// Some endpoints have been removed from the service.
         #[prost(message, tag="2")]
         Remove(super::AddrSet),
-        ///  `no_endpoints{exists: false}` indicates that the service does not exist
-        ///  and the client MAY try an alternate service discovery method (e.g. DNS).
+        /// `no_endpoints{exists: false}` indicates that the service does not exist
+        /// and the client MAY try an alternate service discovery method (e.g. DNS).
         ///
-        ///  `no_endpoints(exists: true)` indicates that the service does exist and
-        ///  the client MUST NOT fall back to an alternate service discovery method.
+        /// `no_endpoints(exists: true)` indicates that the service does exist and
+        /// the client MUST NOT fall back to an alternate service discovery method.
         #[prost(message, tag="3")]
         NoEndpoints(super::NoEndpoints),
     }
@@ -65,7 +65,7 @@ pub struct WeightedAddr {
     #[prost(message, optional, tag="7")]
     pub authority_override: ::core::option::Option<AuthorityOverride>,
 }
-///  Which strategy should be used for verifying TLS.
+/// Which strategy should be used for verifying TLS.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TlsIdentity {
     #[prost(oneof="tls_identity::Strategy", tags="1")]
@@ -73,12 +73,12 @@ pub struct TlsIdentity {
 }
 /// Nested message and enum types in `TlsIdentity`.
 pub mod tls_identity {
-    ///  Verify the certificate based on the Kubernetes pod identity.
+    /// Verify the certificate based on the Kubernetes pod identity.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DnsLikeIdentity {
-        ///  A DNS-like name that encodes workload coordinates.
+        /// A DNS-like name that encodes workload coordinates.
         ///
-        ///  For example:
+        /// For example:
         ///     {name}.{namespace}.{type}.identity.{control-namespace}.{trust-domain...}
         #[prost(string, tag="1")]
         pub name: ::prost::alloc::string::String,
@@ -99,12 +99,12 @@ pub struct NoEndpoints {
     #[prost(bool, tag="1")]
     pub exists: bool,
 }
-///  A hint of what protocol the service knows. The default value is
-///  for the `hint` field to be not be set, essentially meaning "unknown".
+/// A hint of what protocol the service knows. The default value is
+/// for the `hint` field to be not be set, essentially meaning "unknown".
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProtocolHint {
-    ///  When set, indicates that the target supports receiving opaque traffic
-    ///  wrapped with the Linkerd connection header on the specified port.
+    /// When set, indicates that the target supports receiving opaque traffic
+    /// wrapped with the Linkerd connection header on the specified port.
     #[prost(message, optional, tag="2")]
     pub opaque_transport: ::core::option::Option<protocol_hint::OpaqueTransport>,
     #[prost(oneof="protocol_hint::Protocol", tags="1")]
@@ -117,114 +117,114 @@ pub mod protocol_hint {
     }
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct OpaqueTransport {
-        ///  The target proxy's inbound port.
+        /// The target proxy's inbound port.
         #[prost(uint32, tag="1")]
         pub inbound_port: u32,
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Protocol {
-        ///  Hints that the service understands HTTP2 and the proxy's internal
-        ///  http2-upgrade mechanism.
+        /// Hints that the service understands HTTP2 and the proxy's internal
+        /// http2-upgrade mechanism.
         #[prost(message, tag="1")]
         H2(H2),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DestinationProfile {
-    ///  The fully-qualified service name, if one exists.
+    /// The fully-qualified service name, if one exists.
     ///
-    ///  When resolving (especially by IP), this field provides the fully-qualified
-    ///  name of the resolved service, if one exists. This field does NOT include
-    ///  any port information. E.g. a lookup for 10.2.3.4:8080 might have a name
-    ///  like `foo.bar.svc.cluster.local`.
+    /// When resolving (especially by IP), this field provides the fully-qualified
+    /// name of the resolved service, if one exists. This field does NOT include
+    /// any port information. E.g. a lookup for 10.2.3.4:8080 might have a name
+    /// like `foo.bar.svc.cluster.local`.
     ///
-    ///  Implementations MAY provide names for non-service IP-lookups (e.g., pod or
-    ///  node dns names), but this is not required.
+    /// Implementations MAY provide names for non-service IP-lookups (e.g., pod or
+    /// node dns names), but this is not required.
     ///
-    ///  If the lookup does not refer to a known named entity, this field MUST be
-    ///  left empty.
+    /// If the lookup does not refer to a known named entity, this field MUST be
+    /// left empty.
     #[prost(string, tag="5")]
     pub fully_qualified_name: ::prost::alloc::string::String,
-    ///  Indicates that connections on this service address should be handled as
-    ///  opaque TCP streams. HTTP routes returned on for such services will be
-    ///  ignored.
+    /// Indicates that connections on this service address should be handled as
+    /// opaque TCP streams. HTTP routes returned on for such services will be
+    /// ignored.
     #[prost(bool, tag="4")]
     pub opaque_protocol: bool,
-    ///  A list of routes, each with a RequestMatch.  If a request matches
-    ///  more than one route, the first match wins.
+    /// A list of routes, each with a RequestMatch.  If a request matches
+    /// more than one route, the first match wins.
     #[prost(message, repeated, tag="1")]
     pub routes: ::prost::alloc::vec::Vec<Route>,
-    ///  The retry budget controls how much additional load the proxy can generate
-    ///  as retries. Failured requests on retryable routes will not be retried if
-    ///  there is no available budget.
+    /// The retry budget controls how much additional load the proxy can generate
+    /// as retries. Failured requests on retryable routes will not be retried if
+    /// there is no available budget.
     #[prost(message, optional, tag="2")]
     pub retry_budget: ::core::option::Option<RetryBudget>,
-    ///  If this list is non-empty, requests to this destination should instead be
-    ///  split between the destinations in this list.  Each destination should
-    ///  receive a portion of the requests proportional to its weight.  If this
-    ///  list is empty, requests should be sent to this destination as normal.
+    /// If this list is non-empty, requests to this destination should instead be
+    /// split between the destinations in this list.  Each destination should
+    /// receive a portion of the requests proportional to its weight.  If this
+    /// list is empty, requests should be sent to this destination as normal.
     #[prost(message, repeated, tag="3")]
     pub dst_overrides: ::prost::alloc::vec::Vec<WeightedDst>,
-    ///  If this field is set, it indicates that the target is a known endpoint (and
-    ///  not a service address). The values of `fully_qualified_name` and
-    ///  `dst_overrides` will be ignored for the purposes of service discovery--
-    ///  traffic split and load balancing will be skipped and the single endpoint
-    ///  are used.
+    /// If this field is set, it indicates that the target is a known endpoint (and
+    /// not a service address). The values of `fully_qualified_name` and
+    /// `dst_overrides` will be ignored for the purposes of service discovery--
+    /// traffic split and load balancing will be skipped and the single endpoint
+    /// are used.
     ///
-    ///  No endpoint should be set If the target is unknown.
+    /// No endpoint should be set If the target is unknown.
     #[prost(message, optional, tag="6")]
     pub endpoint: ::core::option::Option<WeightedAddr>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Route {
-    ///  This route contains requests which match this condition.
+    /// This route contains requests which match this condition.
     #[prost(message, optional, tag="1")]
     pub condition: ::core::option::Option<RequestMatch>,
-    ///  A list of response classes for this route.  If a response matches
-    ///  more than one ResponseClass, the first match wins.  If a response does not
-    ///  match any ResponseClasses, it is considered to be a successful response.
+    /// A list of response classes for this route.  If a response matches
+    /// more than one ResponseClass, the first match wins.  If a response does not
+    /// match any ResponseClasses, it is considered to be a successful response.
     #[prost(message, repeated, tag="2")]
     pub response_classes: ::prost::alloc::vec::Vec<ResponseClass>,
-    ///  Metric labels to attach to requests and responses that match this route.
+    /// Metric labels to attach to requests and responses that match this route.
     #[prost(map="string, string", tag="3")]
     pub metrics_labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    ///  If a route is retryable, any failed requests on that route may be retried
-    ///  by the proxy.
+    /// If a route is retryable, any failed requests on that route may be retried
+    /// by the proxy.
     #[prost(bool, tag="4")]
     pub is_retryable: bool,
-    ///  After this time has elapsed since receiving the initial request, any
-    ///  outstanding request will be cancelled, a timeout error response will be
-    ///  returned, and no more retries will be attempted.
+    /// After this time has elapsed since receiving the initial request, any
+    /// outstanding request will be cancelled, a timeout error response will be
+    /// returned, and no more retries will be attempted.
     #[prost(message, optional, tag="5")]
     pub timeout: ::core::option::Option<::prost_types::Duration>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetryBudget {
-    ///  The ratio of additional traffic that may be added by retries.  A
-    ///  retry_ratio of 0.1 means that 1 retry may be attempted for every 10 regular
-    ///  requests.  A retry_ratio of 1.0 means that 1 retry may be attempted for
-    ///  every 1 regular request (in other words, total request load may be doubled
-    ///  as a result of retries).
+    /// The ratio of additional traffic that may be added by retries.  A
+    /// retry_ratio of 0.1 means that 1 retry may be attempted for every 10 regular
+    /// requests.  A retry_ratio of 1.0 means that 1 retry may be attempted for
+    /// every 1 regular request (in other words, total request load may be doubled
+    /// as a result of retries).
     #[prost(float, tag="1")]
     pub retry_ratio: f32,
-    ///  The proxy may always attempt this number of retries per second, even if it
-    ///  would violate the retry_ratio.  This is to allow retries to happen even
-    ///  when the request rate is very low.
+    /// The proxy may always attempt this number of retries per second, even if it
+    /// would violate the retry_ratio.  This is to allow retries to happen even
+    /// when the request rate is very low.
     #[prost(uint32, tag="2")]
     pub min_retries_per_second: u32,
-    ///  This duration indicates for how long requests should be considered for the
-    ///  purposes of enforcing the retry_ratio.  A higher value considers a larger
-    ///  window and therefore allows burstier retries.
+    /// This duration indicates for how long requests should be considered for the
+    /// purposes of enforcing the retry_ratio.  A higher value considers a larger
+    /// window and therefore allows burstier retries.
     #[prost(message, optional, tag="3")]
     pub ttl: ::core::option::Option<::prost_types::Duration>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseClass {
-    ///  This class contains responses which match this condition.
+    /// This class contains responses which match this condition.
     #[prost(message, optional, tag="1")]
     pub condition: ::core::option::Option<ResponseMatch>,
-    ///  If responses in this class should be considered failures.  This defaults
-    ///  to false (success).
+    /// If responses in this class should be considered failures.  This defaults
+    /// to false (success).
     #[prost(bool, tag="2")]
     pub is_failure: bool,
 }
@@ -250,14 +250,14 @@ pub mod request_match {
         Not(::prost::alloc::boxed::Box<super::RequestMatch>),
         #[prost(message, tag="4")]
         Path(super::PathMatch),
-        ///  TODO: match on arbitrary header
+        /// TODO: match on arbitrary header
         #[prost(message, tag="5")]
         Method(super::super::http_types::HttpMethod),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PathMatch {
-    ///  Match if the request path matches this regex.
+    /// Match if the request path matches this regex.
     #[prost(string, tag="1")]
     pub regex: ::prost::alloc::string::String,
 }
@@ -281,30 +281,30 @@ pub mod response_match {
         Any(Seq),
         #[prost(message, tag="3")]
         Not(::prost::alloc::boxed::Box<super::ResponseMatch>),
-        ///  TODO: match on arbitrary header or trailer
+        /// TODO: match on arbitrary header or trailer
         #[prost(message, tag="4")]
         Status(super::HttpStatusRange),
     }
 }
-///  If either a minimum or maximum is not specified, the range is considered to
-///  be over a discrete value.
+/// If either a minimum or maximum is not specified, the range is considered to
+/// be over a discrete value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpStatusRange {
-    ///  Minimum matching http status code (inclusive), if specified.
+    /// Minimum matching http status code (inclusive), if specified.
     #[prost(uint32, tag="1")]
     pub min: u32,
-    ///  Maximum matching http status code (inclusive), if specified.
+    /// Maximum matching http status code (inclusive), if specified.
     #[prost(uint32, tag="2")]
     pub max: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WeightedDst {
-    ///  This authority will be used as the `path` in a call to the Destination.Get
-    ///  rpc.
+    /// This authority will be used as the `path` in a call to the Destination.Get
+    /// rpc.
     #[prost(string, tag="1")]
     pub authority: ::prost::alloc::string::String,
-    ///  The proportion of requests to send to this destination.  This value is
-    ///  relative to other weights in the same dst_overrides list.
+    /// The proportion of requests to send to this destination.  This value is
+    /// relative to other weights in the same dst_overrides list.
     #[prost(uint32, tag="2")]
     pub weight: u32,
 }

--- a/src/gen/io.linkerd.proxy.grpc_route.rs
+++ b/src/gen/io.linkerd.proxy.grpc_route.rs
@@ -2,9 +2,9 @@
 pub struct GrpcRouteMatch {
     #[prost(message, optional, tag="1")]
     pub rpc: ::core::option::Option<GrpcRpcMatch>,
-    ///  A set of header value matches that must be satisified. This match is not
-    ///  comprehensive, so requests may include headers that are not covered by this
-    ///  match.
+    /// A set of header value matches that must be satisified. This match is not
+    /// comprehensive, so requests may include headers that are not covered by this
+    /// match.
     #[prost(message, repeated, tag="2")]
     pub headers: ::prost::alloc::vec::Vec<super::http_route::HeaderMatch>,
 }
@@ -15,17 +15,17 @@ pub struct GrpcRpcMatch {
     #[prost(string, tag="2")]
     pub method: ::prost::alloc::string::String,
 }
-///  Configures a route to respond with a fixed response.
+/// Configures a route to respond with a fixed response.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GrpcFailureInjector {
-    ///  The status code to use in the `grpc-status` response. Must be specified.
+    /// The status code to use in the `grpc-status` response. Must be specified.
     #[prost(uint32, tag="1")]
     pub code: u32,
-    ///  An error message to log and include in the `grpc-message` header.
+    /// An error message to log and include in the `grpc-message` header.
     #[prost(string, tag="2")]
     pub message: ::prost::alloc::string::String,
-    ///  If specified, the rate of requests that should be failed. If not specified,
-    ///  ALL requests are failed.
+    /// If specified, the rate of requests that should be failed. If not specified,
+    /// ALL requests are failed.
     #[prost(message, optional, tag="3")]
     pub ratio: ::core::option::Option<super::http_route::Ratio>,
 }

--- a/src/gen/io.linkerd.proxy.http_route.rs
+++ b/src/gen/io.linkerd.proxy.http_route.rs
@@ -1,4 +1,4 @@
-///  Describes how to match an `:authority` or `host` header.
+/// Describes how to match an `:authority` or `host` header.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostMatch {
     #[prost(oneof="host_match::Match", tags="1, 2")]
@@ -6,7 +6,7 @@ pub struct HostMatch {
 }
 /// Nested message and enum types in `HostMatch`.
 pub mod host_match {
-    ///  A match like `*.example.com` is encoded as [com, example].
+    /// A match like `*.example.com` is encoded as [com, example].
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Suffix {
         #[prost(string, repeated, tag="1")]
@@ -14,35 +14,35 @@ pub mod host_match {
     }
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Match {
-        ///  Match an exact hostname, e.g. www.example.com.
+        /// Match an exact hostname, e.g. www.example.com.
         #[prost(string, tag="1")]
         Exact(::prost::alloc::string::String),
-        ///  Match a hostname as a wildcard suffix, e.g. *.example.com.
+        /// Match a hostname as a wildcard suffix, e.g. *.example.com.
         #[prost(message, tag="2")]
         Suffix(Suffix),
     }
 }
-///  Describes a set of matches, ALL of which must apply.
+/// Describes a set of matches, ALL of which must apply.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpRouteMatch {
-    ///  Matches requests by path.
+    /// Matches requests by path.
     #[prost(message, optional, tag="1")]
     pub path: ::core::option::Option<PathMatch>,
-    ///  A set of header value matches that must be satisified. This match is not
-    ///  comprehensive, so requests may include headers that are not covered by this
-    ///  match.
+    /// A set of header value matches that must be satisified. This match is not
+    /// comprehensive, so requests may include headers that are not covered by this
+    /// match.
     #[prost(message, repeated, tag="2")]
     pub headers: ::prost::alloc::vec::Vec<HeaderMatch>,
-    ///  A set of query parmaeter value matches that must be satisified. This match
-    ///  is not comprehensive, so requests may include query parameters that are not
-    ///  covered by this match.
+    /// A set of query parmaeter value matches that must be satisified. This match
+    /// is not comprehensive, so requests may include query parameters that are not
+    /// covered by this match.
     #[prost(message, repeated, tag="3")]
     pub query_params: ::prost::alloc::vec::Vec<QueryParamMatch>,
-    ///  If specified, restricts the match to a single HTTP method.
+    /// If specified, restricts the match to a single HTTP method.
     #[prost(message, optional, tag="4")]
     pub method: ::core::option::Option<super::http_types::HttpMethod>,
 }
-///  Describes how to match a path.
+/// Describes how to match a path.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PathMatch {
     #[prost(oneof="path_match::Kind", tags="1, 2, 3")]
@@ -60,7 +60,7 @@ pub mod path_match {
         Regex(::prost::alloc::string::String),
     }
 }
-///  Describes how to match a header by name and value.
+/// Describes how to match a header by name and value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeaderMatch {
     #[prost(string, tag="1")]
@@ -78,7 +78,7 @@ pub mod header_match {
         Regex(::prost::alloc::string::String),
     }
 }
-///  Describes how to match a query parameter by name and value.
+/// Describes how to match a query parameter by name and value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryParamMatch {
     #[prost(string, tag="1")]
@@ -96,50 +96,50 @@ pub mod query_param_match {
         Regex(::prost::alloc::string::String),
     }
 }
-///  Configures a route to modify a request's headers.
+/// Configures a route to modify a request's headers.
 ///
-///  Modifications are to be applied in the order they are described here:
-///  additions apply first, then sets, and then removals.
+/// Modifications are to be applied in the order they are described here:
+/// additions apply first, then sets, and then removals.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestHeaderModifier {
-    ///  A list of headers name-value pairs to set on requests, augmenting any
-    ///  existing values for the header.
+    /// A list of headers name-value pairs to set on requests, augmenting any
+    /// existing values for the header.
     #[prost(message, optional, tag="1")]
     pub add: ::core::option::Option<super::http_types::Headers>,
-    ///  A list of headers name-value pairs to set on requests, replacing any
-    ///  existing values for the header.
+    /// A list of headers name-value pairs to set on requests, replacing any
+    /// existing values for the header.
     #[prost(message, optional, tag="2")]
     pub set: ::core::option::Option<super::http_types::Headers>,
-    ///  A list of headers names to be removed from requests.
+    /// A list of headers names to be removed from requests.
     #[prost(string, repeated, tag="3")]
     pub remove: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-///  Configures a route to respond with a redirect response. The `location` header
-///  is set with the given URL parameters.
+/// Configures a route to respond with a redirect response. The `location` header
+/// is set with the given URL parameters.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestRedirect {
-    ///  The scheme value to be used in the `location` header. If not specified,
-    ///  the original request's scheme is used.
+    /// The scheme value to be used in the `location` header. If not specified,
+    /// the original request's scheme is used.
     #[prost(message, optional, tag="1")]
     pub scheme: ::core::option::Option<super::http_types::Scheme>,
-    ///  The host value to be used in the `location` header. If not specified, the
-    ///  original request's host is used.
+    /// The host value to be used in the `location` header. If not specified, the
+    /// original request's host is used.
     #[prost(string, tag="2")]
     pub host: ::prost::alloc::string::String,
-    ///  If set, configures how the request's path should be modified for use in
-    ///  the `location` header. If not specified, the original request's path is
-    ///  used.
+    /// If set, configures how the request's path should be modified for use in
+    /// the `location` header. If not specified, the original request's path is
+    /// used.
     #[prost(message, optional, tag="3")]
     pub path: ::core::option::Option<PathModifier>,
-    ///  If set, specifies the port to use in the `location` header.
+    /// If set, specifies the port to use in the `location` header.
     #[prost(uint32, tag="4")]
     pub port: u32,
-    ///  The status code to use in the HTTP response. If not specified, 301 is
-    ///  used.
+    /// The status code to use in the HTTP response. If not specified, 301 is
+    /// used.
     #[prost(uint32, tag="5")]
     pub status: u32,
 }
-///  Describes how a path value may be rewritten in a route.
+/// Describes how a path value may be rewritten in a route.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PathModifier {
     #[prost(oneof="path_modifier::Replace", tags="1, 2")]
@@ -149,41 +149,41 @@ pub struct PathModifier {
 pub mod path_modifier {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Replace {
-        ///  Indicates that the path should be replaced with the given value.
+        /// Indicates that the path should be replaced with the given value.
         #[prost(string, tag="1")]
         Full(::prost::alloc::string::String),
-        ///  Indicates that the path prefix should be replaced with the given
-        ///  value. When used, the route MUST match the request with PathMatch
-        ///  prefix match. Server implementations SHOULD prevent the useof prefix
-        ///  modifiers on routes that do use a PathMatch prefix match. Proxyies
-        ///  MUST not process requests for routes where this condition is not
-        ///  satisfied.
+        /// Indicates that the path prefix should be replaced with the given
+        /// value. When used, the route MUST match the request with PathMatch
+        /// prefix match. Server implementations SHOULD prevent the useof prefix
+        /// modifiers on routes that do use a PathMatch prefix match. Proxyies
+        /// MUST not process requests for routes where this condition is not
+        /// satisfied.
         #[prost(string, tag="2")]
         Prefix(::prost::alloc::string::String),
     }
 }
-///  Configures a route to respond with a fixed response.
+/// Configures a route to respond with a fixed response.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpFailureInjector {
-    ///  The status code to use in the HTTP response. Must be specified.
+    /// The status code to use in the HTTP response. Must be specified.
     #[prost(uint32, tag="1")]
     pub status: u32,
-    ///  An error message to log and include in the `l5d-proxy-err` header.
+    /// An error message to log and include in the `l5d-proxy-err` header.
     #[prost(string, tag="2")]
     pub message: ::prost::alloc::string::String,
-    ///  If specified, the rate of requests that should be failed. If not specified,
-    ///  ALL requests are failed.
+    /// If specified, the rate of requests that should be failed. If not specified,
+    /// ALL requests are failed.
     #[prost(message, optional, tag="3")]
     pub ratio: ::core::option::Option<Ratio>,
 }
-///  A ratio (i.e., of requests) to which an filter should be applied.
+/// A ratio (i.e., of requests) to which an filter should be applied.
 ///
-///  Represents fractional values on [0, 1].
+/// Represents fractional values on [0, 1].
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ratio {
     #[prost(uint32, tag="1")]
     pub numerator: u32,
-    ///  MUST not be zero.
+    /// MUST not be zero.
     #[prost(uint32, tag="2")]
     pub denominator: u32,
 }

--- a/src/gen/io.linkerd.proxy.identity.rs
+++ b/src/gen/io.linkerd.proxy.identity.rs
@@ -2,23 +2,23 @@
 pub struct CertifyRequest {
     #[prost(string, tag="1")]
     pub identity: ::prost::alloc::string::String,
-    ///  Proof of the requester's identity.
+    /// Proof of the requester's identity.
     ///
-    ///  In Kubernetes, for instance, this is the contents of a service account
-    ///  token.
+    /// In Kubernetes, for instance, this is the contents of a service account
+    /// token.
     #[prost(bytes="vec", tag="2")]
     pub token: ::prost::alloc::vec::Vec<u8>,
-    ///  A PEM-encoded x509 Certificate Signing Request.
+    /// A PEM-encoded x509 Certificate Signing Request.
     #[prost(bytes="vec", tag="3")]
     pub certificate_signing_request: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CertifyResponse {
-    ///  A PEM-encoded x509 Certificate.
+    /// A PEM-encoded x509 Certificate.
     #[prost(bytes="vec", tag="1")]
     pub leaf_certificate: ::prost::alloc::vec::Vec<u8>,
-    ///  A list of PEM-encoded x509 Certificates that establish the trust chain
-    ///  between the leaf_certificate and the well-known trust anchors.
+    /// A list of PEM-encoded x509 Certificates that establish the trust chain
+    /// between the leaf_certificate and the well-known trust anchors.
     #[prost(bytes="vec", repeated, tag="2")]
     pub intermediate_certificates: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(message, optional, tag="3")]

--- a/src/gen/io.linkerd.proxy.inbound.rs
+++ b/src/gen/io.linkerd.proxy.inbound.rs
@@ -1,31 +1,31 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PortSpec {
-    ///  Identifies a proxy workload (e.g., pod name).
+    /// Identifies a proxy workload (e.g., pod name).
     #[prost(string, tag="1")]
     pub workload: ::prost::alloc::string::String,
-    ///  An inbound port on _workload_.
+    /// An inbound port on _workload_.
     #[prost(uint32, tag="2")]
     pub port: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Server {
-    ///  If set, indicates how the proxy should proxy connections on the specified
-    ///  port.
+    /// If set, indicates how the proxy should proxy connections on the specified
+    /// port.
     #[prost(message, optional, tag="1")]
     pub protocol: ::core::option::Option<ProxyProtocol>,
-    ///  Indicates the IP addresses on which the proxy may receive connections.
-    ///  Connections targetting other IP addresses will be dropped.
+    /// Indicates the IP addresses on which the proxy may receive connections.
+    /// Connections targetting other IP addresses will be dropped.
     #[prost(message, repeated, tag="2")]
     pub server_ips: ::prost::alloc::vec::Vec<super::net::IpAddress>,
-    ///  Configures a proxy to allow connections from the specified clients.
+    /// Configures a proxy to allow connections from the specified clients.
     ///
-    ///  If unset, no connections are permitted.
+    /// If unset, no connections are permitted.
     #[prost(message, repeated, tag="3")]
     pub authorizations: ::prost::alloc::vec::Vec<Authz>,
-    ///  Descriptive labels to be added to metrics, etc.
+    /// Descriptive labels to be added to metrics, etc.
     ///
-    ///  A control plane SHOULD return the same keys in all policies. That is, we do
-    ///  NOT want to return arbitrary pod labels in this field.
+    /// A control plane SHOULD return the same keys in all policies. That is, we do
+    /// NOT want to return arbitrary pod labels in this field.
     #[prost(map="string, string", tag="4")]
     pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
@@ -40,8 +40,8 @@ pub mod proxy_protocol {
     pub struct Detect {
         #[prost(message, optional, tag="1")]
         pub timeout: ::core::option::Option<::prost_types::Duration>,
-        ///  If the protocol detected as HTTP, a list of HTTP routes that should be
-        ///  matched.
+        /// If the protocol detected as HTTP, a list of HTTP routes that should be
+        /// matched.
         #[prost(message, repeated, tag="3")]
         pub http_routes: ::prost::alloc::vec::Vec<super::HttpRoute>,
     }
@@ -60,7 +60,7 @@ pub mod proxy_protocol {
         #[prost(message, repeated, tag="2")]
         pub routes: ::prost::alloc::vec::Vec<super::GrpcRoute>,
     }
-    ///  TODO: opaque TLS settings (versions, algorithms, SNI)
+    /// TODO: opaque TLS settings (versions, algorithms, SNI)
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Opaque {
     }
@@ -85,32 +85,32 @@ pub mod proxy_protocol {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Authz {
-    ///  Limits this authorization to client addresses in the provided networks.
+    /// Limits this authorization to client addresses in the provided networks.
     ///
-    ///  Must have at least one network, otherwise the authorization must be
-    ///  ignored. An authorization matches all clients by including an explicit
-    ///  match on, i.e., `[0.0.0.0/0, 0::/0]``.
+    /// Must have at least one network, otherwise the authorization must be
+    /// ignored. An authorization matches all clients by including an explicit
+    /// match on, i.e., `[0.0.0.0/0, 0::/0]``.
     #[prost(message, repeated, tag="1")]
     pub networks: ::prost::alloc::vec::Vec<Network>,
-    ///  Must be set.
+    /// Must be set.
     #[prost(message, optional, tag="2")]
     pub authentication: ::core::option::Option<Authn>,
-    ///  Descriptive labels to be added to metrics, etc.
+    /// Descriptive labels to be added to metrics, etc.
     ///
-    ///  A control plane SHOULD return the same keys in all authorizations. That is,
-    ///  we do NOT want to return arbitrary pod labels in this field.
+    /// A control plane SHOULD return the same keys in all authorizations. That is,
+    /// we do NOT want to return arbitrary pod labels in this field.
     ///
-    ///  `labels` should be considered deprecated. `metadata` is preferred. However,
-    ///  controllers should continue to set `labels` for compatibility with older
-    ///  proxies.
+    /// `labels` should be considered deprecated. `metadata` is preferred. However,
+    /// controllers should continue to set `labels` for compatibility with older
+    /// proxies.
     #[prost(map="string, string", tag="3")]
     pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    ///  If set, describes an Authorization configuration. Replaces the free-from
-    ///  `labels` field.
+    /// If set, describes an Authorization configuration. Replaces the free-from
+    /// `labels` field.
     #[prost(message, optional, tag="4")]
     pub metadata: ::core::option::Option<super::meta::Metadata>,
 }
-///  Describes a network of authorized clients.
+/// Describes a network of authorized clients.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Network {
     #[prost(message, optional, tag="1")]
@@ -125,8 +125,8 @@ pub struct Authn {
 }
 /// Nested message and enum types in `Authn`.
 pub mod authn {
-    //  TODO(ver) identify authentication resources?
-    //  io.linkerd.proxy.meta.Metadata metadata = 3;
+    // TODO(ver) identify authentication resources?
+    // io.linkerd.proxy.meta.Metadata metadata = 3;
 
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PermitUnauthenticated {
@@ -140,22 +140,22 @@ pub mod authn {
     pub mod permit_mesh_tls {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct PermitClientIdentities {
-            ///  A list of literal identities.
+            /// A list of literal identities.
             #[prost(message, repeated, tag="1")]
             pub identities: ::prost::alloc::vec::Vec<super::super::Identity>,
-            ///  A list of identity suffixes.
+            /// A list of identity suffixes.
             ///
-            ///  If this contains an empty suffix, all identities are matched.
+            /// If this contains an empty suffix, all identities are matched.
             #[prost(message, repeated, tag="2")]
             pub suffixes: ::prost::alloc::vec::Vec<super::super::IdentitySuffix>,
         }
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Clients {
-            ///  Indicates that client identities are not required.
+            /// Indicates that client identities are not required.
             #[prost(message, tag="1")]
             Unauthenticated(super::PermitUnauthenticated),
-            ///  Indicates that mutually-authenticated connections are permitted from
-            ///  clients with matching identities.
+            /// Indicates that mutually-authenticated connections are permitted from
+            /// clients with matching identities.
             #[prost(message, tag="2")]
             Identities(PermitClientIdentities),
         }
@@ -164,7 +164,7 @@ pub mod authn {
     pub enum Permit {
         #[prost(message, tag="1")]
         Unauthenticated(PermitUnauthenticated),
-        ///  If set, requires that the connection is transported over mesh TLS.
+        /// If set, requires that the connection is transported over mesh TLS.
         #[prost(message, tag="2")]
         MeshTls(PermitMeshTls),
     }
@@ -174,30 +174,30 @@ pub struct Identity {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
 }
-///  Encodes a DNS-like name suffix as sequence of parts.
+/// Encodes a DNS-like name suffix as sequence of parts.
 ///
-///  An empty list is equivalent to `.` (matching all names); the list `["foo",
-///  "bar"]` is equivalent to "foo.bar." (matching `*.foo.bar`), etc.
+/// An empty list is equivalent to `.` (matching all names); the list `["foo",
+/// "bar"]` is equivalent to "foo.bar." (matching `*.foo.bar`), etc.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentitySuffix {
     #[prost(string, repeated, tag="1")]
     pub parts: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-///  Inbound-specific HTTP route configuration (based on the [Gateway API]\[api\]).
+/// Inbound-specific HTTP route configuration (based on the [Gateway API]\[api\]).
 ///
-///  \[api\]: <https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute>
+/// \[api\]: <https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute>
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpRoute {
     #[prost(message, optional, tag="1")]
     pub metadata: ::core::option::Option<super::meta::Metadata>,
-    ///  If empty, the host value is ignored.
+    /// If empty, the host value is ignored.
     #[prost(message, repeated, tag="2")]
     pub hosts: ::prost::alloc::vec::Vec<super::http_route::HostMatch>,
-    ///  Extends the list of authorizations on the `Server` with authorizations
-    ///  specific to this route.
+    /// Extends the list of authorizations on the `Server` with authorizations
+    /// specific to this route.
     #[prost(message, repeated, tag="3")]
     pub authorizations: ::prost::alloc::vec::Vec<Authz>,
-    ///  Must have at least one rule.
+    /// Must have at least one rule.
     #[prost(message, repeated, tag="4")]
     pub rules: ::prost::alloc::vec::Vec<http_route::Rule>,
 }
@@ -228,19 +228,19 @@ pub mod http_route {
         }
     }
 }
-///  Inbound-specific gRPC route configuration.
+/// Inbound-specific gRPC route configuration.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GrpcRoute {
     #[prost(message, optional, tag="1")]
     pub metadata: ::core::option::Option<super::meta::Metadata>,
-    ///  If empty, the host value is ignored.
+    /// If empty, the host value is ignored.
     #[prost(message, repeated, tag="2")]
     pub hosts: ::prost::alloc::vec::Vec<super::http_route::HostMatch>,
-    ///  The server MUST return at least one authorization, otherwise all requests
-    ///  to this route will fail with an unauthorized response.
+    /// The server MUST return at least one authorization, otherwise all requests
+    /// to this route will fail with an unauthorized response.
     #[prost(message, repeated, tag="3")]
     pub authorizations: ::prost::alloc::vec::Vec<Authz>,
-    ///  Must have at least one rule.
+    /// Must have at least one rule.
     #[prost(message, repeated, tag="4")]
     pub rules: ::prost::alloc::vec::Vec<grpc_route::Rule>,
 }

--- a/src/gen/io.linkerd.proxy.meta.rs
+++ b/src/gen/io.linkerd.proxy.meta.rs
@@ -1,5 +1,5 @@
-///  General metadata about a configuration object. Typically references either an
-///  implicit default configuration or a Kubernetes resource.
+/// General metadata about a configuration object. Typically references either an
+/// implicit default configuration or a Kubernetes resource.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metadata {
     #[prost(oneof="metadata::Kind", tags="1, 2")]
@@ -9,18 +9,18 @@ pub struct Metadata {
 pub mod metadata {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
-        ///  A name describing a default/implicit configuration.
+        /// A name describing a default/implicit configuration.
         ///
-        ///  For example, a policy default name like `all-authenticated` describes an
-        ///  implicit controller-implementedc policy that does not exist as a cluster
-        ///  resource.
+        /// For example, a policy default name like `all-authenticated` describes an
+        /// implicit controller-implementedc policy that does not exist as a cluster
+        /// resource.
         #[prost(string, tag="1")]
         Default(::prost::alloc::string::String),
         #[prost(message, tag="2")]
         Resource(super::Resource),
     }
 }
-///  References a (e.g., Kubernetes) resource.
+/// References a (e.g., Kubernetes) resource.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {
     #[prost(string, tag="1")]

--- a/src/gen/io.linkerd.proxy.net.rs
+++ b/src/gen/io.linkerd.proxy.net.rs
@@ -22,10 +22,10 @@ pub struct IpNetwork {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IPv6 {
-    ///  hextets 1-4
+    /// hextets 1-4
     #[prost(fixed64, tag="1")]
     pub first: u64,
-    ///  hextets 5-8
+    /// hextets 5-8
     #[prost(fixed64, tag="2")]
     pub last: u64,
 }

--- a/src/gen/io.linkerd.proxy.tap.rs
+++ b/src/gen/io.linkerd.proxy.tap.rs
@@ -1,13 +1,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObserveRequest {
-    ///  Limits the number of event keys that will be returned by this tap.
+    /// Limits the number of event keys that will be returned by this tap.
     #[prost(uint32, tag="1")]
     pub limit: u32,
-    ///  Encodes request-matching logic.
+    /// Encodes request-matching logic.
     #[prost(message, optional, tag="2")]
     pub r#match: ::core::option::Option<observe_request::Match>,
-    ///  Conditionally extracts components from requests and responses to include
-    ///  in tap events
+    /// Conditionally extracts components from requests and responses to include
+    /// in tap events
     #[prost(message, optional, tag="3")]
     pub extract: ::core::option::Option<observe_request::Extract>,
 }
@@ -46,14 +46,14 @@ pub mod observe_request {
                 #[prost(uint32, tag="2")]
                 pub mask: u32,
             }
-            ///  If either a minimum or maximum is not specified, the range is
-            ///  considered to be over a discrete value.
+            /// If either a minimum or maximum is not specified, the range is
+            /// considered to be over a discrete value.
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct PortRange {
-                ///  Minimum matching port value (inclusive), if specified.
+                /// Minimum matching port value (inclusive), if specified.
                 #[prost(uint32, tag="1")]
                 pub min: u32,
-                ///  Maximum matching port value (inclusive), if specified.
+                /// Maximum matching port value (inclusive), if specified.
                 #[prost(uint32, tag="2")]
                 pub max: u32,
             }
@@ -95,7 +95,7 @@ pub mod observe_request {
                 Method(super::super::super::super::http_types::HttpMethod),
                 #[prost(message, tag="2")]
                 Authority(StringMatch),
-                ///  TODO Header        header    = 4;
+                /// TODO Header        header    = 4;
                 #[prost(message, tag="4")]
                 Path(StringMatch),
             }
@@ -203,10 +203,10 @@ pub mod tap_event {
     pub mod http {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct StreamId {
-            ///  A randomized base (stable across a process's runtime)
+            /// A randomized base (stable across a process's runtime)
             #[prost(uint32, tag="1")]
             pub base: u32,
-            ///  A stream id unique within the lifetime of `base`.
+            /// A stream id unique within the lifetime of `base`.
             #[prost(uint64, tag="2")]
             pub stream: u64,
         }


### PR DESCRIPTION
Version 0.11.0 of `prost-build` had a (very minor) bug where an
additional character of whitespace was added in front of RustDoc
comments. Version 0.11.1 fixes that.

This branch updates to v0.11.1 and regens the protos (again).

Closes #140