### PR TITLE
actions: fix wrong substring match in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           ref='${{ github.ref }}'
           if [[ "$ref" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo ::set-output name=publish::true
-            echo ::set-output name=version::"${ref##refs/tags/release/}"
+            echo ::set-output name=version::"${ref##refs/tags/}"
           else
             sha=${{ github.sha }}
             echo ::set-output name=version::"test-${sha:0:7}"


### PR DESCRIPTION
This appears to expect that the release tag is named `release/vX.Y.Z` rather than just `vX.Y.Z`, but all the existing release tags use the second naming format. This is preventing v0.8.0 from being released, as the publish action fails with
```
Error: Crate version v0.8.0 does not match tag refs/tags/v0.8.0
```
because the refs path was not removed (as it's expected to be `refs/tags/release/` rather than refs/tags/`).

I'm...not entirely sure how this ever worked previously...