### PR TITLE
v0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,6 @@
 ## v0.9.0
 
 * Add new `OutboundPolicies` API
-* Add circuit-breaker configuration to `OutboundPolicy`
-* Add `Metadata` to `OutboundPolicy` responses
-* Add `port` field to `OutboundPolicy` resource `Metadata`
 * Go: update `google.golang.org/grpc` to v1.53
 
 ## v0.8.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # `linkerd2-proxy-api` changes
 
+## v0.9.0
+
+* Add new `OutboundPolicies` API
+* Add circuit-breaker configuration to `OutboundPolicy`
+* Add `Metadata` to `OutboundPolicy` responses
+* Add `port` field to `OutboundPolicy` resource `Metadata`
+* Go: update `google.golang.org/grpc` to v1.53
+
 ## v0.8.0
 
 * Add `Opaque` variant to `destination.ProtocolHint`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## v0.9.0

* Add new `OutboundPolicies` API
* Add circuit-breaker configuration to `OutboundPolicy`
* Add `Metadata` to `OutboundPolicy` responses
* Add `port` field to `OutboundPolicy` resource `Metadata`
* Go: update `google.golang.org/grpc` to v1.53