### PR TITLE
build(deps): update `h2` from v0.3.17 to v0.3.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
Apparently v0.3.17 is yanked, which is causing our CI build to complain at us:
https://github.com/linkerd/linkerd2-proxy-api/actions/runs/5093960127/jobs/9157185970?pr=243

This PR fixes it.