### PR TITLE
v0.10.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # `linkerd2-proxy-api` changes
 
+## v0.10.0
+
+* Add `requestTimeout` fields to routes and route backends in the
+  `OutboundPolicies` API
+* Rust: update `h2` to v0.3.17
+
 ## v0.9.0
 
 * Add new `OutboundPolicies` API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## v0.10.0

* Add `requestTimeout` fields to routes and route backends in the `OutboundPolicies` API
* Rust: update `h2` to v0.3.17