### PR TITLE
ci: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
         run: |
           ref='${{ github.ref }}'
           if [[ "$ref" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo ::set-output name=publish::true
-            echo ::set-output name=version::"${ref##refs/tags/}"
+            echo publish=true >> "$GITHUB_OUTPUT"
+            echo version="${ref##refs/tags/}" >> "$GITHUB_OUTPUT"
           else
             sha=${{ github.sha }}
-            echo ::set-output name=version::"test-${sha:0:7}"
+            echo version="test-${sha:0:7}" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       publish: ${{ steps.meta.outputs.publish }}


### PR DESCRIPTION
The release workflow uses a deprecated syntax, which now fails linting.

This change updates the syntax to the correct version.