### PR TITLE
chore(deps): add `prost` and `tonic` dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      prost:
+        patterns:
+          - "prost*"
+      tonic:
+        patterns:
+          - "tonic*"
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
this commit adds two groups to the dependabot configuration.

this will mean that dependabot updates (a) `tonic` and `tonic-build,` and (b) `prost` and `prost-types`, in lockstep.