### PR TITLE
chore: update rust-version to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://linkerd.io"
 repository = "https://github.com/linkerd/linkerd2-proxy-api"
 documentation = "https://docs.rs/linkerd2-proxy-api"
 keywords = ["linkerd", "grpc", "servicemesh"]
-rust-version = "1.59"
+rust-version = "1.90"
 
 [features]
 default = []


### PR DESCRIPTION
this commit updates the `rust-version` field, so that we can update our
dependencies to more recent versions.

this field has not been updated in many years, which means that we've
fallen out of step with the devcontainer used to build linkerd, and
cannot pull in equivalent dependencies.

see:

- https://github.com/linkerd/dev/blob/main/Dockerfile#L9
- https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
- https://doc.rust-lang.org/cargo/reference/rust-version.html

Signed-off-by: katelyn martin <kate@buoyant.io>
