### PR TITLE
chore(deny): allow same licenses as linkerd2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://linkerd.io"
 repository = "https://github.com/linkerd/linkerd2-proxy-api"
 documentation = "https://docs.rs/linkerd2-proxy-api"
 keywords = ["linkerd", "grpc", "servicemesh"]
-rust-version = "1.59"
+rust-version = "1.90"
 
 [features]
 default = []

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,12 @@ exceptions = [
 ]
 allow = [
     "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
     "MIT",
+    "Unicode-3.0",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
see linkerd/linkerd2-proxy-api#562.

this commit updates our deny.toml file to allow the same licenses that
linkerd2 and linkerd2-proxy allow.

this way, we can update our dependency tree to use the same dependencies
that our data and control planes use.

Signed-off-by: katelyn martin <kate@buoyant.io>
