### PR TITLE
chore: prepare for v0.20.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd2-proxy-api"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
this commit updates the crate version from 0.19.0 to 0.20.0.

Signed-off-by: katelyn martin <kate@buoyant.io>
