### PR TITLE
chore(build): bump dev container to v50

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2-proxy-api",
-    "image": "ghcr.io/linkerd/dev:v48",
+    "image": "ghcr.io/linkerd/dev:v50",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
   go:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-go
+    container: docker://ghcr.io/linkerd/dev:v50-go
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just go-mod-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
   test:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just rs-fetch
@@ -56,7 +56,7 @@ jobs:
       contents: write
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - if: needs.meta.outputs.publish
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -80,7 +80,7 @@ jobs:
     needs: [meta, release]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - if: '!needs.meta.outputs.publish'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
   gen-check:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just rs-fetch
@@ -31,7 +31,7 @@ jobs:
   rust-clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just rs-fetch
@@ -40,7 +40,7 @@ jobs:
   rust-docs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just rs-fetch
@@ -49,7 +49,7 @@ jobs:
   rust-test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v48-rust
+    container: docker://ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - run: just rs-fetch


### PR DESCRIPTION
Followup to #569, addressing those places that dependabot doesn't cover.